### PR TITLE
Workaround for rvest/selectr/covr bug

### DIFF
--- a/R/gutenberg_download.R
+++ b/R/gutenberg_download.R
@@ -210,8 +210,7 @@ gutenberg_get_mirror <- function(verbose = TRUE) {
   }
   wget_url <- "http://www.gutenberg.org/robot/harvest?filetypes[]=txt"
   mirror_full_url <- xml2::read_html(wget_url) %>%
-    rvest::html_nodes("a") %>%
-    .[[1]] %>%
+    xml2::xml_find_one(".//a") %>%
     rvest::html_attr("href")
 
   # parse and leave out the path


### PR DESCRIPTION
I am still not entirely sure what is causing this issue. There seems to be a problem with `rvest:::make_selector()` or `selectr::css_to_xpath()` that only happens on travis with a traced function. See (https://travis-ci.org/jimhester/gutenbergr/builds/128154686#L613-L654) for the traceback.

Until the error is resolved a workround is to just use `xml2::xml_find_one()` directly with a XPath selector.
Which fixes the issue (e.g. https://travis-ci.org/jimhester/gutenbergr/builds/128159467#L529-L532)